### PR TITLE
Handle AUX interrupts during sleep

### DIFF
--- a/src/SPD2010Touch.cpp
+++ b/src/SPD2010Touch.cpp
@@ -208,6 +208,19 @@ bool SPD2010Touch::readStatusLength(TouchStatus& status) {
     return true;
 }
 
+bool SPD2010Touch::enableAuxInterrupt(bool enable) {
+    uint8_t data[2];
+    if (!readRegister(SPD2010_INT_MASK_REG, data, 2)) {
+        return false;
+    }
+    if (enable) {
+        data[0] |= SPD2010_AUX_INT_BIT;
+    } else {
+        data[0] &= ~SPD2010_AUX_INT_BIT;
+    }
+    return writeCommand(SPD2010_INT_MASK_REG, data, 2);
+}
+
 bool SPD2010Touch::readHDP(const TouchStatus& status, TouchData& touch) {
     uint8_t data[64]; // Maximum expected data size
     if (!readRegister(0x0300, data, status.read_len)) {

--- a/src/SPD2010Touch.h
+++ b/src/SPD2010Touch.h
@@ -8,6 +8,11 @@
 #define SPD2010_I2C_ADDRESS 0x53
 #define SPD2010_MAX_TOUCH_POINTS 10
 
+// Register used to enable/disable individual interrupts
+#define SPD2010_INT_MASK_REG 0x0014
+// Bit controlling AUX interrupt generation
+#define SPD2010_AUX_INT_BIT 0x08
+
 // Touch point structure
 struct TouchPoint {
     uint8_t id;
@@ -97,8 +102,9 @@ public:
     bool readFirmwareVersion();
     
     // Set interrupt callback
-    void setInterruptCallback(void (*callback)());    
+    void setInterruptCallback(void (*callback)());
     bool writeClearIntCommand();
+    bool enableAuxInterrupt(bool enable);
 
     
 private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -680,9 +680,11 @@ void loop()
     // Inactivity check for sleep
     if (millis() - lastInteractionTime > (currentSettings.sleep_duration *1000)) {
         setJustAwakeFlag = true;
-           touch.writeClearIntCommand();
-           delay(10);
+        touch.enableAuxInterrupt(false);
+        touch.writeClearIntCommand();
+        delay(10);
         powerManager.goToSleep();
+        touch.enableAuxInterrupt(true);
     }
 
      if(millis() - lastInteractionTime > (currentSettings.screen_dim_duration *1000) && !isScreenDimmed) {


### PR DESCRIPTION
## Summary
- add constants for SPD2010 interrupt masking
- expose `enableAuxInterrupt` for SPD2010Touch
- implement interrupt mask write logic
- disable AUX interrupts before going to sleep and restore them afterwards

## Testing
- `pio run -t clean` *(fails: PlatformIO could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6887cc8d4440832fa741a2fb703d2029